### PR TITLE
Revert the way of generating hashsum files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,9 @@ jobs:
           install -p $GOPATH/src/$GEOSITE_REPO/data/{proxy,direct,reject}-list.txt ./publish/
           cd ./publish
           zip rules.zip {proxy,direct,reject}-list.txt geoip.dat geosite.dat
-          sha256sum geoip.dat geosite.dat rules.zip > sha256sum
+          sha256sum geoip.dat > geoip.dat.sha256sum
+          sha256sum geosite.dat > geosite.dat.sha256sum
+          sha256sum rules.zip > rules.zip.sha256sum
 
       - name: Release and upload assets
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
有鉴于 [v2fly/fhs-install-v2ray](https://github.com/v2fly/fhs-install-v2ray) 极可能会成为未来官方钦定的一种 dat 文件更新标准，最近在 build.yml 上所做的更改是值得商榷的。
我的建议是该 fork 不应该与上游的行为不同，否则如果用户替换 v2fly 的 dat-install 脚本中更新源地址就会遇到问题。

---

如果这一改动是因为加入 scoop 支持引入的，我建议维护 scoop 库的人遵守上游的文件验证方式。