### PR TITLE
Add hackinn.com & zh.okaapps.com to direct list

### DIFF
--- a/direct.txt
+++ b/direct.txt
@@ -1,0 +1,1 @@
+hackinn.com

--- a/direct.txt
+++ b/direct.txt
@@ -1,1 +1,2 @@
 hackinn.com
+zh.okaapps.com


### PR DESCRIPTION
These domains have been accepted with ICP Licensing.
- [www.hackinn.com](https://www.hackinn.com/)
- [data.hackinn.com](https://data.hackinn.com/)

[zh.okaapps.com](https://zh.okaapps.com) is assigned to Alicloud IP.