### PR TITLE
Do not reject cdn.mouseflow.com

### DIFF
--- a/reject-need-to-remove.txt
+++ b/reject-need-to-remove.txt
@@ -5,6 +5,7 @@ alimama.alicdn.com
 alimama.com
 analytics.google.com
 bdtj.tagtic.cn
+domain:cdn.mouseflow.com
 d.ifengimg.com
 icons.mydrivers.com
 img.alibaba.com


### PR DESCRIPTION
- Still reject other subdomains of mouseflow.com
- But no rejection for cdn.mouseflow.com, which is necessary when completing orders using freedomains.

Note: mouseflow.com is not blocked in [upstream:v2fly/domain-list-community](https://github.com/v2fly/domain-list-community). Don't know why mouseflow.com is blocked. In order to keep the minimized functions, this time only remove `cdn.mouseflow.com` from rejection list.