### PR TITLE
更新 DNS 配置方式 例子中的1.1.1.1 CloudFlare DOH 地址 | Update the 1.1.1.1 CloudF…

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ steamstatic.com.8686c.com @cn
   },
   "servers": [
     {
-      "address": "https://1.1.1.1/dns-query",
+      "address": "https://cloudflare-dns.com/dns-query",
       "domains": ["geosite:geolocation-!cn"],
       "expectIPs": ["geoip:!cn"]
     },


### PR DESCRIPTION
…lare DOH address in the DNS configuration example

现在CLoudFlare中的DNS指南已将IP地址修改为域名,我在使用V2rayN在Windows平台下遇到了报错问题,将`https://1.1.1.1/dns-query`更换为`https://cloudflare-dns.com/dns-query`之后解决了这个问题,所以发布了Pull Request.

请作者查看,如有错误请谅解,第一次发.
参考
https://developers.cloudflare.com/1.1.1.1/encryption/dns-over-https/make-api-requests/