### PR TITLE
build: always using latest go version of `1.x`

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ^1.18
+          check-latest: true
 
       - name: Set variables
         run: |


### PR DESCRIPTION
`actions/setup-go@v3` has added the `check-latest` flag to use the latest go version.
By using `go-version: ^1.18`, only `1.x` version will be used.

Reference: [actions/setup-go@v3](https://github.com/actions/setup-go#check-latest-version), [version-control](https://github.com/npm/node-semver#caret-ranges-123-025-004)