### PR TITLE
Hidden

### DIFF
--- a/proxy.txt
+++ b/proxy.txt
@@ -1,1 +1,2 @@
 supertop.co
+telegra.ph

--- a/reject.txt
+++ b/reject.txt
@@ -1,0 +1,1 @@
+sb.firefox.com.cn


### PR DESCRIPTION
添加的 `sb.firefox.com.cn` 是Firefox中国特供版的一个“探测器”域名，实测reject之后不会出现某些网站被禁止访问的问题。