### PR TITLE
Hidden

### DIFF
--- a/proxy.txt
+++ b/proxy.txt
@@ -1,1 +1,2 @@
 supertop.co
+telegra.ph

--- a/reject-need-to-remove.txt
+++ b/reject-need-to-remove.txt
@@ -21,7 +21,6 @@ s.youtube.com
 sf3-ttcdn-tos.pstatp.com
 t.co
 tagtic.cn
-telegra.ph
 tongji.baidu.com
 tv.sohu.com
 ue.yeyoucdn.com

--- a/reject.txt
+++ b/reject.txt
@@ -1,0 +1,1 @@
+sb.firefox.com.cn


### PR DESCRIPTION
`reject.txt` 中添加的 `sb.firefox.com.cn` 是Firefox中国特供版的一个“探测器”域名，实测reject之后不会出现某些网站被禁止访问的问题。