### PR TITLE
ci: enable v2dat patch run

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -211,6 +211,12 @@ jobs:
           pwd
           echo "number of files: $(ls publish/ | wc -l)"
 
+      - name: Extract geoip.dat as *.txt artifacts
+        run: |
+          mkdir out
+          ./v2dat unpack geoip -o out publish/geoip.dat
+          zip -j geoip.zip out/*.txt
+
       - name: Extract geosite.dat as *.txt artifacts
         run: |
           mkdir out
@@ -220,8 +226,10 @@ jobs:
       - name: Export artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: geosite_artifacts
-          path: geosite.zip
+          name: artifacts
+          path: |
+            geoip.zip
+            geosite.zip
 
   publish:
     needs: [build, extract-artifact]
@@ -244,19 +252,22 @@ jobs:
       - name: Copy artifacts from extract-artifact job to local path
         uses: actions/download-artifact@v3
         with:
-          name: geosite_artifacts
+          name: artifacts
 
       - name: Extract artifacts
         shell: bash
         run: |
           ls
+          unzip geoip.zip -d geoip/
           unzip geosite.zip -d geosite/
+          mv geoip.zip publish/
           mv geosite.zip publish/
 
       - name: Verify contents
         shell: bash
         run: |
           pwd
+          echo "number of files in geoip/: $(ls geoip/ | wc -l)"
           echo "number of files in geosite/: $(ls geosite/ | wc -l)"
 
       - name: Release and upload assets

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -238,8 +238,7 @@ jobs:
       - name: Set variables
         shell: bash
         run: |
-          echo "RELEASE_NAME=$(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
-          echo "TAG_NAME=$(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
+          echo "RELEASE_DATE=$(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
 
       - name: Checkout the master branch of this repo
         uses: actions/checkout@v3
@@ -267,11 +266,11 @@ jobs:
       - name: Release and upload assets
         uses: softprops/action-gh-release@v1
         with:
-          name: ${{ env.RELEASE_NAME }}
-          tag_name: ${{ env.TAG_NAME }}
+          name: ${{ env.RELEASE_DATE }}
+          tag_name: ${{ env.RELEASE_DATE }}
           draft: false
           prerelease: false
-          body: "Release on {{ env.RELEASE_NAME }}"
+          body: "Release on {{ env.RELEASE_DATE }}"
           files: |
             publish/*
         env:
@@ -286,6 +285,6 @@ jobs:
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b release
           git add .
-          git commit -m "${{ env.RELEASE_NAME }}"
+          git commit -m "${{ env.RELEASE_DATE }}"
           git remote add origin "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
           git push -f -u origin release

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -213,6 +213,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: pre_flight_artifacts
+          path: publish
 
       - name: Verify contents
         shell: bash

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -270,7 +270,7 @@ jobs:
           tag_name: ${{ env.RELEASE_DATE }}
           draft: false
           prerelease: false
-          body: "Release on {{ env.RELEASE_DATE }}"
+          body: "Release on ${{ env.RELEASE_DATE }}"
           files: |
             publish/*
         env:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -272,13 +272,12 @@ jobs:
           echo "number of files in geosite/: $(ls geosite/ | wc -l)"
 
       - name: Release and upload assets
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v0.1.6
         with:
           name: ${{ env.RELEASE_NAME }}
           tag_name: ${{ env.TAG_NAME }}
           draft: false
           prerelease: false
-          generate_release_notes: true
           files: |
             publish/*
         env:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -203,7 +203,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: techprober/v2dat
-          ref: master
 
       - name: Build binary
         run: |
@@ -245,8 +244,6 @@ jobs:
 
       - name: Checkout the master branch of this repo
         uses: actions/checkout@v3
-        with:
-          ref: master
 
       - name: Copy artifacts from previous job to local path
         uses: actions/download-artifact@v3

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -219,19 +219,18 @@ jobs:
         shell: bash
         run: |
           pwd
-          ls ./publish | wc -l
+          echo "number of files: $(ls ./publish | wc -l)"
 
       - name: Extract geosite.dat as *.txt artifacts
         run: |
           mkdir out
-          ./v2dat unpack geosite -o out geosite.dat
+          ./v2dat unpack geosite -o out publish/geosite.dat
 
       - name: Export artifacts
         uses: actions/upload-artifact@v3
         with:
           name: geosite_artifacts
           path: out
-
 
   publish:
     needs: [build, extract-artifact]
@@ -251,11 +250,13 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: geosite_artifacts
+          path: artifacts
 
       - name: Verify contents
         shell: bash
         run: |
-          ls ./out | wc -l
+          pwd
+          echo "number of files: $(ls ./artifacts | wc -l)"
 
       # - name: Release and upload assets
       #   uses: softprops/action-gh-release@v0.1.6

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -28,7 +28,6 @@ jobs:
           echo "GREATFIRE_DOMAINS_URL=https://raw.githubusercontent.com/Loyalsoldier/cn-blocked-domain/release/domains.txt" >> $GITHUB_ENV
           echo "EASYLISTCHINA_EASYLIST_REJECT_URL=https://easylist-downloads.adblockplus.org/easylistchina+easylist.txt" >> $GITHUB_ENV
           echo "BLUESKYXN_ALL_REJECT_URL=https://raw.githubusercontent.com/BlueSkyXN/AdGuardHomeRules/master/all.txt" >> $GITHUB_ENV
-          echo "TRACKING_REJECT_URL=https://blocklistproject.github.io/Lists/dnsmasq-version/tracking-dnsmasq.txt" >> $GITHUB_ENV
           echo "MALWARE_REJECT_URL=https://blocklistproject.github.io/Lists/dnsmasq-version/malware-dnsmasq.txt" >> $GITHUB_ENV
           echo "SCAME_REJECT_URL=https://blocklistproject.github.io/Lists/dnsmasq-version/scam-dnsmasq.txt" >> $GITHUB_ENV
           echo "PETERLOWE_REJECT_URL=https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=1&mimetype=plaintext" >> $GITHUB_ENV
@@ -92,7 +91,6 @@ jobs:
         run: |
           curl -sSL $EASYLISTCHINA_EASYLIST_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
           curl -sSL $BLUESKYXN_ALL_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
-          curl -sSL $TRACKING_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
           curl -sSL $MALWARE_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
           curl -sSL $SCAME_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
           curl -sSL $ADGUARD_DNS_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' >> temp-reject.txt

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -217,7 +217,8 @@ jobs:
       - name: Verify contents
         shell: bash
         run: |
-          ls ./publish | wc -l
+          pwd
+          ls ./pre_flight_artifacts | wc -l
 
       - name: Extract geosite.dat as *.txt artifacts
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -219,18 +219,19 @@ jobs:
         shell: bash
         run: |
           pwd
-          echo "number of files: $(ls ./publish | wc -l)"
+          echo "number of files: $(ls publish/ | wc -l)"
 
       - name: Extract geosite.dat as *.txt artifacts
         run: |
           mkdir out
           ./v2dat unpack geosite -o out publish/geosite.dat
+          zip out.zip out/*.txt
 
       - name: Export artifacts
         uses: actions/upload-artifact@v3
         with:
           name: geosite_artifacts
-          path: out
+          path: out.zip
 
   publish:
     needs: [build, extract-artifact]
@@ -252,11 +253,16 @@ jobs:
           name: geosite_artifacts
           path: artifacts
 
+      - name: Extract artifacts
+        shell: bash
+        run: |
+          unzip artifacts.zip -d artifacts/
+
       - name: Verify contents
         shell: bash
         run: |
           pwd
-          echo "number of files: $(ls ./artifacts | wc -l)"
+          echo "number of files: $(ls artifacts/ | wc -l)"
 
       # - name: Release and upload assets
       #   uses: softprops/action-gh-release@v0.1.6

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -230,8 +230,8 @@ jobs:
       - name: Set variables
         shell: bash
         run: |
-          echo "RELEASE_NAME=Released on $(date +%Y%m%d%H%M)" >> $GITHUB_ENV
-          echo "TAG_NAME=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
+          echo "RELEASE_NAME=Released on $(date +%Y-%m-%d-%H%M)" >> $GITHUB_ENV
+          echo "TAG_NAME=$(date +%Y-%m-%d-%H%M)" >> $GITHUB_ENV
 
       - name: Checkout the master branch of this repo
         uses: actions/checkout@v3
@@ -251,6 +251,7 @@ jobs:
       - name: Extract artifacts
         shell: bash
         run: |
+          ls
           unzip geosite.zip -d geosite/
           mv geosite.zip publish/
 
@@ -268,7 +269,7 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            ./publish/*
+            publish/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -11,14 +11,6 @@ on:
     paths-ignore:
       - "**/README.md"
 
-# Workflow related global environment variables
-# env:
-#   ENV: staging
-#   REPOSITORY: hikariai-web
-#   REGISTRY: docker.io
-#   REGISTRY_USERNAME: hikariai
-#   IMAGE_TAG: staging
-
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build:
@@ -32,8 +24,6 @@ jobs:
       - name: Set variables
         shell: bash
         run: |
-          echo "RELEASE_NAME=Released on $(date +%Y%m%d%H%M)" >> $GITHUB_ENV
-          echo "TAG_NAME=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
           echo "CHINA_DOMAINS_URL=https://raw.githubusercontent.com/felixonmars/dnsmasq-china-list/master/accelerated-domains.china.conf" >> $GITHUB_ENV
           echo "GOOGLE_DOMAINS_URL=https://raw.githubusercontent.com/felixonmars/dnsmasq-china-list/master/google.china.conf" >> $GITHUB_ENV
           echo "APPLE_DOMAINS_URL=https://raw.githubusercontent.com/felixonmars/dnsmasq-china-list/master/apple.china.conf" >> $GITHUB_ENV
@@ -225,66 +215,72 @@ jobs:
         run: |
           mkdir out
           ./v2dat unpack geosite -o out publish/geosite.dat
-          zip -j artifacts.zip out/*.txt
+          zip -j geosite.zip out/*.txt
 
       - name: Export artifacts
         uses: actions/upload-artifact@v3
         with:
           name: geosite_artifacts
-          path: artifacts.zip
+          path: geosite.zip
 
   publish:
     needs: [build, extract-artifact]
     runs-on: ubuntu-latest
     steps:
-      # - name: Set variables
-      #   shell: bash
-      #   run: |
-      #     echo "RELEASE_NAME=Released on $(date +%Y%m%d%H%M)" >> $GITHUB_ENV
-      #     echo "TAG_NAME=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
-      #     echo "CHINA_DOMAINS_URL=https://raw.githubusercontent.com/felixonmars/dnsmasq-china-list/master/accelerated-domains.china.conf" >> $GITHUB_ENV
+      - name: Set variables
+        shell: bash
+        run: |
+          echo "RELEASE_NAME=Released on $(date +%Y%m%d%H%M)" >> $GITHUB_ENV
+          echo "TAG_NAME=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
 
       - name: Checkout the master branch of this repo
         uses: actions/checkout@v3
 
-      - name: Copy artifacts from previous job to local path
+      - name: Copy artifacts from build job to local path
+        uses: actions/download-artifact@v3
+        with:
+          name: pre_flight_artifacts
+          path: publish/
+
+      - name: Copy artifacts from extract-artifact job to local path
         uses: actions/download-artifact@v3
         with:
           name: geosite_artifacts
+          path: geosite.zip
 
       - name: Extract artifacts
         shell: bash
         run: |
-          ls
-          unzip artifacts.zip -d artifacts/
+          unzip geosite.zip -d geosite/
+          mv geosite.zip publish/
 
       - name: Verify contents
         shell: bash
         run: |
           pwd
-          echo "number of files: $(ls artifacts/ | wc -l)"
+          echo "number of files in geosite/: $(ls geosite/ | wc -l)"
 
-      # - name: Release and upload assets
-      #   uses: softprops/action-gh-release@v0.1.6
-      #   with:
-      #     name: ${{ env.RELEASE_NAME }}
-      #     tag_name: ${{ env.TAG_NAME }}
-      #     draft: false
-      #     prerelease: false
-      #     files: |
-      #       ./publish/*
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release and upload assets
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ env.RELEASE_NAME }}
+          tag_name: ${{ env.TAG_NAME }}
+          draft: false
+          prerelease: false
+          files: |
+            ./publish/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Git push assets to "release" branch
-      #   shell: bash
-      #   run: |
-      #     cd publish || exit 1
-      #     git init
-      #     git config --local user.name "github-actions[bot]"
-      #     git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      #     git checkout -b release
-      #     git add .
-      #     git commit -m "${{ env.RELEASE_NAME }}"
-      #     git remote add origin "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
-      #     git push -f -u origin release
+      - name: Git push assets to "release" branch
+        shell: bash
+        run: |
+          cd publish || exit 1
+          git init
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b release
+          git add .
+          git commit -m "${{ env.RELEASE_NAME }}"
+          git remote add origin "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
+          git push -f -u origin release

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -2,13 +2,23 @@ name: Build V2Ray rules dat files
 on:
   workflow_dispatch:
   schedule:
-    # At 00:00 on Monday every week
-    - cron: "0 0 * * 1"
+    # At 00:00 on Sunday every week
+    - cron: "0 0 * * 7"
   push:
     branches:
       - master
     paths-ignore:
       - "**/README.md"
+
+# Workflow related global environment variables
+env:
+  ENV: staging
+  REPOSITORY: hikariai-web
+  REGISTRY: docker.io
+  REGISTRY_USERNAME: hikariai
+  IMAGE_TAG: staging
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,9 +26,10 @@ jobs:
       - name: Setup Go 1.x.y
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version: ^1.19
 
       - name: Set variables
+        shell: bash
         run: |
           echo "RELEASE_NAME=Released on $(date +%Y%m%d%H%M)" >> $GITHUB_ENV
           echo "TAG_NAME=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
@@ -36,7 +47,6 @@ jobs:
           echo "WIN_SPY=https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/spy.txt" >> $GITHUB_ENV
           echo "WIN_UPDATE=https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/update.txt" >> $GITHUB_ENV
           echo "WIN_EXTRA=https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/extra.txt" >> $GITHUB_ENV
-        shell: bash
 
       - name: Checkout the "hidden" branch of this repo
         uses: actions/checkout@v3
@@ -135,11 +145,8 @@ jobs:
       - name: Remove domains end with ".cn" in "temp-geolocation-!cn.txt" and write lists to data directory
         run: |
           cat temp-cn.txt | sort --ignore-case -u | perl -ne '/^((?=^.{1,255})[a-zA-Z0-9][-_a-zA-Z0-9]{0,62}(\.[a-zA-Z0-9][-_a-zA-Z0-9]{0,62})*)/ && print "$1\n"' > ./community/data/cn
-          cat temp-cn.txt | sort --ignore-case -u | perl -ne 'print if not /^((?=^.{3,255})[a-zA-Z0-9][-_a-zA-Z0-9]{0,62}(\.[a-zA-Z0-9][-_a-zA-Z0-9]{0,62})+)/' > direct-tld-list.txt
           cat temp-geolocation-\!cn.txt | sort --ignore-case -u | perl -ne '/^((?=^.{1,255})[a-zA-Z0-9][-_a-zA-Z0-9]{0,62}(\.[a-zA-Z0-9][-_a-zA-Z0-9]{0,62})*)/ && print "$1\n"' | perl -ne 'print if not /\.cn$/' > ./community/data/geolocation-\!cn
-          cat temp-geolocation-\!cn.txt | sort --ignore-case -u | perl -ne 'print if not /^((?=^.{3,255})[a-zA-Z0-9][-_a-zA-Z0-9]{0,62}(\.[a-zA-Z0-9][-_a-zA-Z0-9]{0,62})+)/' > proxy-tld-list.txt
           cat temp-category-ads-all.txt | sort --ignore-case -u | perl -ne '/^((?=^.{1,255})[a-zA-Z0-9][-_a-zA-Z0-9]{0,62}(\.[a-zA-Z0-9][-_a-zA-Z0-9]{0,62})*)/ && print "$1\n"' > ./community/data/category-ads-all
-          cat temp-category-ads-all.txt | sort --ignore-case -u | perl -ne 'print if not /^((?=^.{3,255})[a-zA-Z0-9][-_a-zA-Z0-9]{0,62}(\.[a-zA-Z0-9][-_a-zA-Z0-9]{0,62})+)/' > reject-tld-list.txt
 
       - name: Add `full`, `regexp` and `keyword` type of rules back into "cn", "geolocation-!cn" and "category-ads-all" list
         run: |
@@ -150,22 +157,15 @@ jobs:
           cp ./community/data/geolocation-\!cn proxy-list.txt
           cp ./community/data/category-ads-all reject-list.txt
 
-      - name: Create `google-cn`、`apple-cn`、`gfw`、`greatfire` lists
+      - name: Create google-cn, apple-cn, gfw, greatfire lists
         run: |
           curl -sSL $GOOGLE_DOMAINS_URL | perl -ne '/^server=\/([^\/]+)\// && print "full:$1\n"' > ./community/data/google-cn
-          curl -sSL $GOOGLE_DOMAINS_URL | perl -ne '/^server=\/([^\/]+)\// && print "full:$1\n"' > google-cn.txt
           curl -sSL $APPLE_DOMAINS_URL | perl -ne '/^server=\/([^\/]+)\// && print "full:$1\n"' > ./community/data/apple-cn
-          curl -sSL $APPLE_DOMAINS_URL | perl -ne '/^server=\/([^\/]+)\// && print "full:$1\n"' > apple-cn.txt
           cat ./gfwlist2dnsmasq/temp-gfwlist.txt | perl -ne '/^((?=^.{3,255})[a-zA-Z0-9][-_a-zA-Z0-9]{0,62}(\.[a-zA-Z0-9][-_a-zA-Z0-9]{0,62})+)/ && print "$1\n"' >> ./community/data/gfw
-          cat ./community/data/gfw | sort --ignore-case -u > gfw.txt
           curl -sSL $GREATFIRE_DOMAINS_URL | perl -ne '/^((?=^.{3,255})[a-zA-Z0-9][-_a-zA-Z0-9]{0,62}(\.[a-zA-Z0-9][-_a-zA-Z0-9]{0,62})+)/ && print "$1\n"' >> ./community/data/greatfire
-          cat ./community/data/greatfire | sort --ignore-case -u > greatfire.txt
           curl -sSL $WIN_SPY | grep "0.0.0.0" | awk '{print $2}' > ./community/data/win-spy
-          curl -sSL $WIN_SPY | grep "0.0.0.0" | awk '{print $2}' > win-spy.txt
           curl -sSL $WIN_UPDATE | grep "0.0.0.0" | awk '{print $2}' > ./community/data/win-update
-          curl -sSL $WIN_UPDATE | grep "0.0.0.0" | awk '{print $2}' > win-update.txt
           curl -sSL $WIN_EXTRA | grep "0.0.0.0" | awk '{print $2}' > ./community/data/win-extra
-          curl -sSL $WIN_EXTRA | grep "0.0.0.0" | awk '{print $2}' > win-extra.txt
 
       - name: Build geosite.dat file
         run: |
@@ -177,34 +177,107 @@ jobs:
           install -Dp ./geoip.dat ./publish/geoip.dat
           install -Dp ./geoip.dat.sha256sum ./publish/geoip.dat.sha256sum
           install -Dp ./custom/publish/geosite.dat ./publish/geosite.dat
-          install -p {proxy,direct,reject}-tld-list.txt ./publish/
           install -p {proxy,direct,reject}-list.txt ./publish/
-          install -p {apple-cn,google-cn,gfw,greatfire,win-spy,win-update,win-extra}.txt ./publish/
           cd ./publish || exit 1
           zip rules.zip {proxy,direct,reject}-list.txt geoip.dat geosite.dat
           sha256sum geosite.dat > geosite.dat.sha256sum
           sha256sum rules.zip > rules.zip.sha256sum
 
-      - name: Release and upload assets
-        uses: softprops/action-gh-release@v0.1.6
+      - name: Export artifacts
+        uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.RELEASE_NAME }}
-          tag_name: ${{ env.TAG_NAME }}
-          draft: false
-          prerelease: false
-          files: |
-            ./publish/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: pre_flight_artifacts
+          path: publish
 
-      - name: Git push assets to "release" branch
+  extract-artifact:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Go 1.x.y
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.19
+
+      - name: Checkout techprober/v2dat
+        uses: actions/checkout@v3
+        with:
+          repository: techprober/v2dat
+          ref: master
+
+      - name: Build binary
         run: |
-          cd publish || exit 1
-          git init
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b release
-          git add .
-          git commit -m "${{ env.RELEASE_NAME }}"
-          git remote add origin "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
-          git push -f -u origin release
+          go build -o v2dat
+          chmod u+x v2dat
+
+      - name: Copy pre-flight artifacts from previous job to local path
+        uses: actions/download-artifact@v3
+        with:
+          name: pre_flight_artifacts
+
+      - name: Verify contents
+        shell: bash
+        run: |
+          ls ./publish | wc -l
+
+      - name: Extract geosite.dat as *.txt artifacts
+        run: |
+          mkdir out
+          ./v2dat unpack geosite -o out geosite.dat
+
+      - name: Export artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: geosite_artifacts
+          path: out
+
+
+  publish:
+    needs: [build, extract-artifact]
+    runs-on: ubuntu-latest
+    steps:
+      # - name: Set variables
+      #   shell: bash
+      #   run: |
+      #     echo "RELEASE_NAME=Released on $(date +%Y%m%d%H%M)" >> $GITHUB_ENV
+      #     echo "TAG_NAME=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
+      #     echo "CHINA_DOMAINS_URL=https://raw.githubusercontent.com/felixonmars/dnsmasq-china-list/master/accelerated-domains.china.conf" >> $GITHUB_ENV
+
+      - name: Checkout the master branch of this repo
+        uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Copy artifacts from previous job to local path
+        uses: actions/download-artifact@v3
+        with:
+          name: geosite_artifacts
+
+      - name: Verify contents
+        shell: bash
+        run: |
+          ls ./out | wc -l
+
+      # - name: Release and upload assets
+      #   uses: softprops/action-gh-release@v0.1.6
+      #   with:
+      #     name: ${{ env.RELEASE_NAME }}
+      #     tag_name: ${{ env.TAG_NAME }}
+      #     draft: false
+      #     prerelease: false
+      #     files: |
+      #       ./publish/*
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # - name: Git push assets to "release" branch
+      #   shell: bash
+      #   run: |
+      #     cd publish || exit 1
+      #     git init
+      #     git config --local user.name "github-actions[bot]"
+      #     git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      #     git checkout -b release
+      #     git add .
+      #     git commit -m "${{ env.RELEASE_NAME }}"
+      #     git remote add origin "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
+      #     git push -f -u origin release

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -271,7 +271,7 @@ jobs:
           tag_name: ${{ env.TAG_NAME }}
           draft: false
           prerelease: false
-          body: "Release on ${{ env.RELEASE_NAME }}"
+          body: "Release on {{ env.RELEASE_NAME }}"
           files: |
             publish/*
         env:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -2,7 +2,8 @@ name: Build V2Ray rules dat files
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 22 * * *"
+    # At 00:00 on Monday every week
+    - cron: "0 0 * * 1"
   push:
     branches:
       - master

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -28,8 +28,6 @@ jobs:
           echo "GREATFIRE_DOMAINS_URL=https://raw.githubusercontent.com/Loyalsoldier/cn-blocked-domain/release/domains.txt" >> $GITHUB_ENV
           echo "EASYLISTCHINA_EASYLIST_REJECT_URL=https://easylist-downloads.adblockplus.org/easylistchina+easylist.txt" >> $GITHUB_ENV
           echo "BLUESKYXN_ALL_REJECT_URL=https://raw.githubusercontent.com/BlueSkyXN/AdGuardHomeRules/master/all.txt" >> $GITHUB_ENV
-          echo "MALWARE_REJECT_URL=https://blocklistproject.github.io/Lists/dnsmasq-version/malware-dnsmasq.txt" >> $GITHUB_ENV
-          echo "SCAME_REJECT_URL=https://blocklistproject.github.io/Lists/dnsmasq-version/scam-dnsmasq.txt" >> $GITHUB_ENV
           echo "PETERLOWE_REJECT_URL=https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=1&mimetype=plaintext" >> $GITHUB_ENV
           echo "ADGUARD_DNS_REJECT_URL=https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt" >> $GITHUB_ENV
           echo "DANPOLLOCK_REJECT_URL=https://someonewhocares.org/hosts/hosts" >> $GITHUB_ENV
@@ -91,8 +89,6 @@ jobs:
         run: |
           curl -sSL $EASYLISTCHINA_EASYLIST_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
           curl -sSL $BLUESKYXN_ALL_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
-          curl -sSL $MALWARE_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
-          curl -sSL $SCAME_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
           curl -sSL $ADGUARD_DNS_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' >> temp-reject.txt
           curl -sSL $PETERLOWE_REJECT_URL | perl -ne '/^127\.0\.0\.1\s([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})$/ && print "$1\n"' >> temp-reject.txt
           curl -sSL $DANPOLLOCK_REJECT_URL | perl -ne '/^127\.0\.0\.1\s([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})/ && print "$1\n"' | sed '1d' >> temp-reject.txt

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -261,8 +261,8 @@ jobs:
           ls
           unzip geoip.zip -d geoip/
           unzip geosite.zip -d geosite/
-          mv geoip.zip publish/
-          mv geosite.zip publish/
+          mv geoip.zip geoip/ publish/
+          mv geosite.zip geosite/ publish/
 
       - name: Verify contents
         shell: bash
@@ -272,12 +272,13 @@ jobs:
           echo "number of files in geosite/: $(ls geosite/ | wc -l)"
 
       - name: Release and upload assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.15
         with:
           name: ${{ env.RELEASE_NAME }}
           tag_name: ${{ env.TAG_NAME }}
           draft: false
           prerelease: false
+          generate_release_notes: true
           files: |
             publish/*
         env:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -251,7 +251,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: geosite_artifacts
-          path: artifacts
+          path: artifacts.zip
 
       - name: Extract artifacts
         shell: bash

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -12,12 +12,12 @@ on:
       - "**/README.md"
 
 # Workflow related global environment variables
-env:
-  ENV: staging
-  REPOSITORY: hikariai-web
-  REGISTRY: docker.io
-  REGISTRY_USERNAME: hikariai
-  IMAGE_TAG: staging
+# env:
+#   ENV: staging
+#   REPOSITORY: hikariai-web
+#   REGISTRY: docker.io
+#   REGISTRY_USERNAME: hikariai
+#   IMAGE_TAG: staging
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -256,6 +256,7 @@ jobs:
       - name: Extract artifacts
         shell: bash
         run: |
+          ls
           unzip artifacts.zip -d artifacts/
 
       - name: Verify contents

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -272,7 +272,7 @@ jobs:
           mv geosite.zip geosite/ publish/
 
       - name: Release and upload assets
-        uses: softprops/action-gh-release@v0.1.8
+        uses: softprops/action-gh-release@v1
         with:
           name: ${{ env.RELEASE_NAME }}
           tag_name: ${{ env.TAG_NAME }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -223,6 +223,13 @@ jobs:
           ./v2dat unpack geosite -o geosite publish/geosite.dat
           zip -j geosite.zip geosite/*.txt
 
+      - name: Verify contents
+        shell: bash
+        run: |
+          pwd
+          echo "number of files in geoip/: $(ls geoip/ | wc -l)"
+          echo "number of files in geosite/: $(ls geosite/ | wc -l)"
+
       - name: Export artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -263,13 +270,6 @@ jobs:
           unzip geosite.zip -d geosite/
           mv geoip.zip geoip/ publish/
           mv geosite.zip geosite/ publish/
-
-      - name: Verify contents
-        shell: bash
-        run: |
-          pwd
-          echo "number of files in geoip/: $(ls geoip/ | wc -l)"
-          echo "number of files in geosite/: $(ls geosite/ | wc -l)"
 
       - name: Release and upload assets
         uses: softprops/action-gh-release@v0.1.8

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -28,6 +28,8 @@ jobs:
           echo "GREATFIRE_DOMAINS_URL=https://raw.githubusercontent.com/Loyalsoldier/cn-blocked-domain/release/domains.txt" >> $GITHUB_ENV
           echo "EASYLISTCHINA_EASYLIST_REJECT_URL=https://easylist-downloads.adblockplus.org/easylistchina+easylist.txt" >> $GITHUB_ENV
           echo "BLUESKYXN_ALL_REJECT_URL=https://raw.githubusercontent.com/BlueSkyXN/AdGuardHomeRules/master/all.txt" >> $GITHUB_ENV
+          echo "TRACKING_REJECT_URL=https://blocklistproject.github.io/Lists/dnsmasq-version/tracking-dnsmasq.txt" >> $GITHUB_ENV
+          echo "MALWARE_REJECT_URL=https://blocklistproject.github.io/Lists/dnsmasq-version/malware-dnsmasq.txt" >> $GITHUB_ENV
           echo "PETERLOWE_REJECT_URL=https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=1&mimetype=plaintext" >> $GITHUB_ENV
           echo "ADGUARD_DNS_REJECT_URL=https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt" >> $GITHUB_ENV
           echo "DANPOLLOCK_REJECT_URL=https://someonewhocares.org/hosts/hosts" >> $GITHUB_ENV
@@ -89,6 +91,8 @@ jobs:
         run: |
           curl -sSL $EASYLISTCHINA_EASYLIST_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
           curl -sSL $BLUESKYXN_ALL_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
+          curl -sSL $TRACKING_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
+          curl -sSL $MALWARE_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
           curl -sSL $ADGUARD_DNS_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' >> temp-reject.txt
           curl -sSL $PETERLOWE_REJECT_URL | perl -ne '/^127\.0\.0\.1\s([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})$/ && print "$1\n"' >> temp-reject.txt
           curl -sSL $DANPOLLOCK_REJECT_URL | perl -ne '/^127\.0\.0\.1\s([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})/ && print "$1\n"' | sed '1d' >> temp-reject.txt

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -221,6 +221,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: geosite_artifacts
+          path: geosite.zip
 
   publish:
     needs: [build, extract-artifact]
@@ -239,13 +240,11 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: pre_flight_artifacts
-          path: publish/
 
       - name: Copy artifacts from extract-artifact job to local path
         uses: actions/download-artifact@v3
         with:
           name: geosite_artifacts
-          path: geosite.zip
 
       - name: Extract artifacts
         shell: bash

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -272,7 +272,7 @@ jobs:
           echo "number of files in geosite/: $(ls geosite/ | wc -l)"
 
       - name: Release and upload assets
-        uses: softprops/action-gh-release@v0.1.6
+        uses: softprops/action-gh-release@v0.1.8
         with:
           name: ${{ env.RELEASE_NAME }}
           tag_name: ${{ env.TAG_NAME }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -264,7 +264,7 @@ jobs:
           mv geosite.zip geosite/ publish/
 
       - name: Release and upload assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.15
         with:
           name: ${{ env.RELEASE_DATE }}
           tag_name: ${{ env.RELEASE_DATE }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -225,13 +225,13 @@ jobs:
         run: |
           mkdir out
           ./v2dat unpack geosite -o out publish/geosite.dat
-          zip out.zip out/*.txt
+          zip -r artifacts.zip out/
 
       - name: Export artifacts
         uses: actions/upload-artifact@v3
         with:
           name: geosite_artifacts
-          path: out.zip
+          path: artifacts.zip
 
   publish:
     needs: [build, extract-artifact]
@@ -251,7 +251,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: geosite_artifacts
-          path: artifacts.zip
 
       - name: Extract artifacts
         shell: bash

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Export artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: artifacts
+          name: post_artifacts
           path: |
             geoip.zip
             geosite.zip
@@ -253,7 +253,7 @@ jobs:
       - name: Copy artifacts from extract-artifact job to local path
         uses: actions/download-artifact@v3
         with:
-          name: artifacts
+          name: post_artifacts
 
       - name: Extract artifacts
         shell: bash

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -225,7 +225,7 @@ jobs:
         run: |
           mkdir out
           ./v2dat unpack geosite -o out publish/geosite.dat
-          zip -r artifacts.zip out/
+          zip -j artifacts.zip out/*.txt
 
       - name: Export artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -221,7 +221,6 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: geosite_artifacts
-          path: geosite.zip
 
   publish:
     needs: [build, extract-artifact]
@@ -230,8 +229,8 @@ jobs:
       - name: Set variables
         shell: bash
         run: |
-          echo "RELEASE_NAME=Released on $(date +%Y-%m-%d-%H%M)" >> $GITHUB_ENV
-          echo "TAG_NAME=$(date +%Y-%m-%d-%H%M)" >> $GITHUB_ENV
+          echo "RELEASE_NAME=Released on $(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
+          echo "TAG_NAME=$(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
 
       - name: Checkout the master branch of this repo
         uses: actions/checkout@v3

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -218,6 +218,7 @@ jobs:
         shell: bash
         run: |
           pwd
+          ls
           ls ./pre_flight_artifacts | wc -l
 
       - name: Extract geosite.dat as *.txt artifacts

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -248,6 +248,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: pre_flight_artifacts
+          path: publish/
 
       - name: Copy artifacts from extract-artifact job to local path
         uses: actions/download-artifact@v3

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -26,6 +26,7 @@ jobs:
           echo "APPLE_DOMAINS_URL=https://raw.githubusercontent.com/felixonmars/dnsmasq-china-list/master/apple.china.conf" >> $GITHUB_ENV
           echo "GREATFIRE_DOMAINS_URL=https://raw.githubusercontent.com/Loyalsoldier/cn-blocked-domain/release/domains.txt" >> $GITHUB_ENV
           echo "EASYLISTCHINA_EASYLIST_REJECT_URL=https://easylist-downloads.adblockplus.org/easylistchina+easylist.txt" >> $GITHUB_ENV
+          echo "BLUESKYXN_ALL_REJECT_URL=https://raw.githubusercontent.com/BlueSkyXN/AdGuardHomeRules/master/all.txt" >> $GITHUB_ENV
           echo "PETERLOWE_REJECT_URL=https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=1&mimetype=plaintext" >> $GITHUB_ENV
           echo "ADGUARD_DNS_REJECT_URL=https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt" >> $GITHUB_ENV
           echo "DANPOLLOCK_REJECT_URL=https://someonewhocares.org/hosts/hosts" >> $GITHUB_ENV
@@ -86,6 +87,7 @@ jobs:
       - name: Get and add reject domains into temp-reject.txt file
         run: |
           curl -sSL $EASYLISTCHINA_EASYLIST_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
+          curl -sSL $BLUESKYXN_ALL_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
           curl -sSL $ADGUARD_DNS_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' >> temp-reject.txt
           curl -sSL $PETERLOWE_REJECT_URL | perl -ne '/^127\.0\.0\.1\s([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})$/ && print "$1\n"' >> temp-reject.txt
           curl -sSL $DANPOLLOCK_REJECT_URL | perl -ne '/^127\.0\.0\.1\s([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})/ && print "$1\n"' | sed '1d' >> temp-reject.txt

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -219,8 +219,7 @@ jobs:
         shell: bash
         run: |
           pwd
-          ls
-          ls ./pre_flight_artifacts | wc -l
+          ls ./publish | wc -l
 
       - name: Extract geosite.dat as *.txt artifacts
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -30,6 +30,7 @@ jobs:
           echo "BLUESKYXN_ALL_REJECT_URL=https://raw.githubusercontent.com/BlueSkyXN/AdGuardHomeRules/master/all.txt" >> $GITHUB_ENV
           echo "TRACKING_REJECT_URL=https://blocklistproject.github.io/Lists/dnsmasq-version/tracking-dnsmasq.txt" >> $GITHUB_ENV
           echo "MALWARE_REJECT_URL=https://blocklistproject.github.io/Lists/dnsmasq-version/malware-dnsmasq.txt" >> $GITHUB_ENV
+          echo "SCAME_REJECT_URL=https://blocklistproject.github.io/Lists/dnsmasq-version/scam-dnsmasq.txt" >> $GITHUB_ENV
           echo "PETERLOWE_REJECT_URL=https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=1&mimetype=plaintext" >> $GITHUB_ENV
           echo "ADGUARD_DNS_REJECT_URL=https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt" >> $GITHUB_ENV
           echo "DANPOLLOCK_REJECT_URL=https://someonewhocares.org/hosts/hosts" >> $GITHUB_ENV
@@ -93,6 +94,7 @@ jobs:
           curl -sSL $BLUESKYXN_ALL_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
           curl -sSL $TRACKING_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
           curl -sSL $MALWARE_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
+          curl -sSL $SCAME_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' > temp-reject.txt
           curl -sSL $ADGUARD_DNS_REJECT_URL | perl -ne '/^\|\|([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})\^$/ && print "$1\n"' | perl -ne 'print if not /^[0-9]{1,3}(\.[0-9]{1,3}){3}$/' >> temp-reject.txt
           curl -sSL $PETERLOWE_REJECT_URL | perl -ne '/^127\.0\.0\.1\s([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})$/ && print "$1\n"' >> temp-reject.txt
           curl -sSL $DANPOLLOCK_REJECT_URL | perl -ne '/^127\.0\.0\.1\s([-_0-9a-zA-Z]+(\.[-_0-9a-zA-Z]+){1,64})/ && print "$1\n"' | sed '1d' >> temp-reject.txt

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -213,14 +213,14 @@ jobs:
 
       - name: Extract geoip.dat as *.txt artifacts
         run: |
-          mkdir out
+          mkdir geoip
           ./v2dat unpack geoip -o geoip publish/geoip.dat
           zip -j geoip.zip geoip/*.txt
 
       - name: Extract geosite.dat as *.txt artifacts
         run: |
-          mkdir out
-          ./v2dat unpack geosite -o out publish/geosite.dat
+          mkdir geosite
+          ./v2dat unpack geosite -o geosite publish/geosite.dat
           zip -j geosite.zip geosite/*.txt
 
       - name: Export artifacts

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -214,14 +214,14 @@ jobs:
       - name: Extract geoip.dat as *.txt artifacts
         run: |
           mkdir out
-          ./v2dat unpack geoip -o out publish/geoip.dat
-          zip -j geoip.zip out/*.txt
+          ./v2dat unpack geoip -o geoip publish/geoip.dat
+          zip -j geoip.zip geoip/*.txt
 
       - name: Extract geosite.dat as *.txt artifacts
         run: |
           mkdir out
           ./v2dat unpack geosite -o out publish/geosite.dat
-          zip -j geosite.zip out/*.txt
+          zip -j geosite.zip geosite/*.txt
 
       - name: Export artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -238,7 +238,7 @@ jobs:
       - name: Set variables
         shell: bash
         run: |
-          echo "RELEASE_NAME=Released on $(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
+          echo "RELEASE_NAME=$(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
           echo "TAG_NAME=$(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
 
       - name: Checkout the master branch of this repo
@@ -271,6 +271,7 @@ jobs:
           tag_name: ${{ env.TAG_NAME }}
           draft: false
           prerelease: false
+          body: "Release on ${{ env.RELEASE_NAME }}"
           files: |
             publish/*
         env:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -3,10 +3,11 @@ on:
   workflow_dispatch:
   schedule:
     # At 00:00 on Sunday every week
-    - cron: "0 0 * * 7"
+    - cron: "0 0 * * 6"
   push:
     branches:
       - master
+      - ci/**
     paths-ignore:
       - "**/README.md"
 

--- a/.github/workflows/staging-run.yml
+++ b/.github/workflows/staging-run.yml
@@ -279,13 +279,14 @@ jobs:
       #       publish/*
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: ncipollo/release-action@v1
         with:
           tag: ${{ env.RELEASE_DATE }}
           draft: false
           prerelease: false
           body: "Release on ${{ env.RELEASE_DATE }}"
-          artifacts: "publish/*"
+          artifacts: "publish/*.txt,publish/*.dat,publish/*.zip"
           token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Git push assets to "release" branch

--- a/.github/workflows/staging-run.yml
+++ b/.github/workflows/staging-run.yml
@@ -242,7 +242,7 @@ jobs:
       - name: Set variables
         shell: bash
         run: |
-          echo "RELEASE_NAME=Released on $(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
+          echo "RELEASE_NAME=$(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
           echo "TAG_NAME=$(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
 
       - name: Checkout the master branch of this repo
@@ -275,6 +275,7 @@ jobs:
           tag_name: ${{ env.TAG_NAME }}
           draft: false
           prerelease: false
+          body: "Release on ${{ env.RELEASE_NAME }}"
           files: |
             publish/*
         env:

--- a/.github/workflows/staging-run.yml
+++ b/.github/workflows/staging-run.yml
@@ -267,27 +267,18 @@ jobs:
           mv geoip.zip geoip/ publish/
           mv geosite.zip geosite/ publish/
 
-      # - name: Release and upload assets
-      #   uses: softprops/action-gh-release@v0.1.15
-      #   with:
-      #     name: ${{ env.RELEASE_DATE }}
-      #     tag_name: ${{ env.RELEASE_DATE }}
-      #     draft: false
-      #     prerelease: false
-      #     body: "Release on ${{ env.RELEASE_DATE }}"
-      #     files: |
-      #       publish/*
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: ncipollo/release-action@v1
+      - name: Release and upload assets
+        uses: softprops/action-gh-release@v0.1.15
         with:
-          tag: ${{ env.RELEASE_DATE }}
+          name: ${{ env.RELEASE_DATE }}
+          tag_name: ${{ env.RELEASE_DATE }}
           draft: false
           prerelease: false
           body: "Release on ${{ env.RELEASE_DATE }}"
-          artifacts: "publish/*.txt,publish/*.dat,publish/*.zip"
-          token: "${{ secrets.GITHUB_TOKEN }}"
+          files: |
+            publish/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Git push assets to "release" branch
         shell: bash

--- a/.github/workflows/staging-run.yml
+++ b/.github/workflows/staging-run.yml
@@ -274,7 +274,7 @@ jobs:
           tag_name: ${{ env.RELEASE_DATE }}
           draft: false
           prerelease: false
-          body: "Release on {{ env.RELEASE_DATE }}"
+          body: "Release on ${{ env.RELEASE_DATE }}"
           files: |
             publish/*
         env:

--- a/.github/workflows/staging-run.yml
+++ b/.github/workflows/staging-run.yml
@@ -270,7 +270,7 @@ jobs:
       - name: Pre-release setup
         shell: bash
         run: |
-          git config --global safe.directory '*'
+          git config --global --add safe.directory '*'
 
       - name: Release and upload assets
         uses: mini-bomba/create-github-release@v1.1.2

--- a/.github/workflows/staging-run.yml
+++ b/.github/workflows/staging-run.yml
@@ -268,7 +268,7 @@ jobs:
           mv geosite.zip geosite/ publish/
 
       - name: Release and upload assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.15
         with:
           name: ${{ env.RELEASE_DATE }}
           tag_name: ${{ env.RELEASE_DATE }}

--- a/.github/workflows/staging-run.yml
+++ b/.github/workflows/staging-run.yml
@@ -243,7 +243,6 @@ jobs:
         shell: bash
         run: |
           echo "RELEASE_NAME=$(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
-          echo "TAG_NAME=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
 
       - name: Checkout the master branch of this repo
         uses: actions/checkout@v3
@@ -268,10 +267,15 @@ jobs:
           mv geoip.zip geoip/ publish/
           mv geosite.zip geosite/ publish/
 
+      - name: Pre-release setup
+        shell: bash
+        run: |
+          git config --global safe.directory '*'
+
       - name: Release and upload assets
         uses: mini-bomba/create-github-release@v1.1.2
         with:
-          tag: "${{ env.TAG_NAME }}"
+          tag: "${{ env.RELEASE_NAME }}"
           name: "${{ env.RELEASE_NAME }}"
           body: |
             Release on ${{ env.RELEASE_NAME }}

--- a/.github/workflows/staging-run.yml
+++ b/.github/workflows/staging-run.yml
@@ -269,16 +269,9 @@ jobs:
           mv geosite.zip geosite/ publish/
 
       - name: Release and upload assets
-        uses: softprops/action-gh-release@v1
-        with:
-          name: ${{ env.RELEASE_NAME }}
-          tag_name: ${{ env.TAG_NAME }}
-          draft: false
-          prerelease: false
-          body: "Release on ${{ env.RELEASE_NAME }}"
-          files: |
-            publish/*
+        uses: fnkr/github-action-ghr@v1
         env:
+          GHR_PATH: publish/
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Git push assets to "release" branch

--- a/.github/workflows/staging-run.yml
+++ b/.github/workflows/staging-run.yml
@@ -267,21 +267,18 @@ jobs:
           mv geoip.zip geoip/ publish/
           mv geosite.zip geosite/ publish/
 
-      - name: Pre-release setup
-        shell: bash
-        run: |
-          git config --global --add safe.directory '*'
-
       - name: Release and upload assets
-        uses: mini-bomba/create-github-release@v1.1.2
+        uses: softprops/action-gh-release@v1
         with:
-          tag: "${{ env.RELEASE_NAME }}"
-          name: "${{ env.RELEASE_NAME }}"
-          body: |
-            Release on ${{ env.RELEASE_NAME }}
+          name: ${{ env.RELEASE_NAME }}
+          tag_name: ${{ env.TAG_NAME }}
+          draft: false
+          prerelease: false
+          body: "Release on {{ env.RELEASE_NAME }}"
           files: |
-            publish/
-          token: ${{ secrets.GITHUB_TOKEN }}
+            publish/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Git push assets to "release" branch
         shell: bash

--- a/.github/workflows/staging-run.yml
+++ b/.github/workflows/staging-run.yml
@@ -243,6 +243,7 @@ jobs:
         shell: bash
         run: |
           echo "RELEASE_NAME=$(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
+          echo "TAG_NAME=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
 
       - name: Checkout the master branch of this repo
         uses: actions/checkout@v3
@@ -270,7 +271,7 @@ jobs:
       - name: Release and upload assets
         uses: mini-bomba/create-github-release@v1.1.2
         with:
-          tag: "${{ env.RELEASE_NAME }}"
+          tag: "${{ env.TAG_NAME }}"
           name: "${{ env.RELEASE_NAME }}"
           body: |
             Release on ${{ env.RELEASE_NAME }}

--- a/.github/workflows/staging-run.yml
+++ b/.github/workflows/staging-run.yml
@@ -1,8 +1,12 @@
-name: Build V2Ray rules dat files (Weekly Trigger)
+name: Build V2Ray rules dat files (Manual Trigger)
 on:
-  schedule:
-    # At 00:00 on Sunday every week
-    - cron: "0 0 * * 6"
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - ci/**
+    paths-ignore:
+      - "**/README.md"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/staging-run.yml
+++ b/.github/workflows/staging-run.yml
@@ -269,10 +269,15 @@ jobs:
           mv geosite.zip geosite/ publish/
 
       - name: Release and upload assets
-        uses: fnkr/github-action-ghr@v1
-        env:
-          GHR_PATH: publish/
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
+        with:
+          tag: "${{ env.RELEASE_NAME }}"
+          name: "${{ env.RELEASE_NAME }}"
+          body: |
+            Release on ${{ env.RELEASE_NAME }}
+          files: |
+            publish/
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Git push assets to "release" branch
         shell: bash

--- a/.github/workflows/staging-run.yml
+++ b/.github/workflows/staging-run.yml
@@ -242,7 +242,7 @@ jobs:
       - name: Set variables
         shell: bash
         run: |
-          echo "RELEASE_NAME=$(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
+          echo "RELEASE_DATE=$(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
 
       - name: Checkout the master branch of this repo
         uses: actions/checkout@v3
@@ -270,11 +270,11 @@ jobs:
       - name: Release and upload assets
         uses: softprops/action-gh-release@v1
         with:
-          name: ${{ env.RELEASE_NAME }}
-          tag_name: ${{ env.TAG_NAME }}
+          name: ${{ env.RELEASE_DATE }}
+          tag_name: ${{ env.RELEASE_DATE }}
           draft: false
           prerelease: false
-          body: "Release on {{ env.RELEASE_NAME }}"
+          body: "Release on {{ env.RELEASE_DATE }}"
           files: |
             publish/*
         env:
@@ -289,6 +289,6 @@ jobs:
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b release
           git add .
-          git commit -m "${{ env.RELEASE_NAME }}"
+          git commit -m "${{ env.RELEASE_DATE }}"
           git remote add origin "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
           git push -f -u origin release

--- a/.github/workflows/staging-run.yml
+++ b/.github/workflows/staging-run.yml
@@ -267,18 +267,26 @@ jobs:
           mv geoip.zip geoip/ publish/
           mv geosite.zip geosite/ publish/
 
-      - name: Release and upload assets
-        uses: softprops/action-gh-release@v0.1.15
+      # - name: Release and upload assets
+      #   uses: softprops/action-gh-release@v0.1.15
+      #   with:
+      #     name: ${{ env.RELEASE_DATE }}
+      #     tag_name: ${{ env.RELEASE_DATE }}
+      #     draft: false
+      #     prerelease: false
+      #     body: "Release on ${{ env.RELEASE_DATE }}"
+      #     files: |
+      #       publish/*
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ncipollo/release-action@v1
         with:
-          name: ${{ env.RELEASE_DATE }}
-          tag_name: ${{ env.RELEASE_DATE }}
+          tag: ${{ env.RELEASE_DATE }}
           draft: false
           prerelease: false
           body: "Release on ${{ env.RELEASE_DATE }}"
-          files: |
-            publish/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "publish/*"
+          token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Git push assets to "release" branch
         shell: bash

--- a/.github/workflows/staging-run.yml
+++ b/.github/workflows/staging-run.yml
@@ -243,7 +243,6 @@ jobs:
         shell: bash
         run: |
           echo "RELEASE_NAME=$(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
-          echo "TAG_NAME=$(date +%Y-%m-%d-%H-%M)" >> $GITHUB_ENV
 
       - name: Checkout the master branch of this repo
         uses: actions/checkout@v3
@@ -269,7 +268,7 @@ jobs:
           mv geosite.zip geosite/ publish/
 
       - name: Release and upload assets
-        uses: softprops/action-gh-release@v1
+        uses: mini-bomba/create-github-release@v1.1.2
         with:
           tag: "${{ env.RELEASE_NAME }}"
           name: "${{ env.RELEASE_NAME }}"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
   - 通过仓库 [@Loyalsoldier/cn-blocked-domain](https://github.com/Loyalsoldier/cn-blocked-domain) 获取 [Greatfire Analyzer](https://zh.greatfire.org/analyzer) 检测到的在中国大陆被屏蔽的域名
   - 加入到 `geosite:greatfire` 类别中，可与上面的 `geosite:gfw` 类别同时使用，以达到域名黑名单的效果
   - 同时加入到 `geosite:geolocation-!cn` 类别中
+- **加入 BLUESKYXN_ALL 广告域名**：通过 [@BlueSkyXN/AdGuardHomeRules](https://raw.githubusercontent.com/BlueSkyXN/AdGuardHomeRules/master/all.txt) 获取并加入到 `geosite:category-ads-all` 类别中
 - **加入 EasyList 和 EasyListChina 广告域名**：通过 [@AdblockPlus/EasylistChina+Easylist.txt](https://easylist-downloads.adblockplus.org/easylistchina+easylist.txt) 获取并加入到 `geosite:category-ads-all` 类别中
 - **加入 AdGuard DNS Filter 广告域名**：通过 [@AdGuard/DNS-filter](https://kb.adguard.com/en/general/adguard-ad-filters#dns-filter) 获取并加入到 `geosite:category-ads-all` 类别中
 - **加入 Peter Lowe 广告和隐私跟踪域名**：通过 [@PeterLowe/adservers](https://pgl.yoyo.org/adservers) 获取并加入到 `geosite:category-ads-all` 类别中

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 简介
 
-[**V2Ray**](https://github.com/v2fly/v2ray-core) 路由规则文件加强版，可代替 V2Ray 官方 `geoip.dat` 和 `geosite.dat`，兼容 [Shadowsocks-windows](https://github.com/shadowsocks/shadowsocks-windows)、[Xray-core](https://github.com/XTLS/Xray-core)、[Trojan-Go](https://github.com/p4gefau1t/trojan-go) 和 [leaf](https://github.com/eycorsican/leaf)。利用 GitHub Actions 北京时间每天早上 6 点自动构建，保证规则最新。
+[**V2Ray**](https://github.com/v2fly/v2ray-core) 路由规则文件加强版，可代替 V2Ray 官方 `geoip.dat` 和 `geosite.dat`，兼容 [Shadowsocks-windows](https://github.com/shadowsocks/shadowsocks-windows)、[Xray-core](https://github.com/XTLS/Xray-core)、[Trojan-Go](https://github.com/p4gefau1t/trojan-go) 和 [leaf](https://github.com/eycorsican/leaf)。利用 GitHub Actions 北京时间每周日凌晨12点自动构建，保证规则最新。
 
 ## 规则文件生成方式
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 简介
 
-[**V2Ray**](https://github.com/v2fly/v2ray-core) 路由规则文件加强版，可代替 V2Ray 官方 `geoip.dat` 和 `geosite.dat`，兼容 [Shadowsocks-windows](https://github.com/shadowsocks/shadowsocks-windows)、[Xray-core](https://github.com/XTLS/Xray-core)、[Trojan-Go](https://github.com/p4gefau1t/trojan-go) 和 [leaf](https://github.com/eycorsican/leaf)。利用 GitHub Actions 北京时间每周日凌晨12点自动构建，保证规则最新。
+[**V2Ray**](https://github.com/v2fly/v2ray-core) 路由规则文件加强版，可代替 V2Ray 官方 `geoip.dat` 和 `geosite.dat`，兼容 [Shadowsocks-windows](https://github.com/shadowsocks/shadowsocks-windows)、[Xray-core](https://github.com/XTLS/Xray-core)、[Trojan-Go](https://github.com/p4gefau1t/trojan-go) 和 [leaf](https://github.com/eycorsican/leaf)。利用 GitHub Actions 北京时间每周日早上8点自动构建，保证规则最新。
 
 ## 规则文件生成方式
 


### PR DESCRIPTION
## Summary

Add support to extract `txt` files from `geoip.dat` and geosite.dat`. All extracted rules (txt) are exported as `geosite.zip` and `geoip.zip` and added to release artifacts for `mosdns-v5` use case.

## Changelogs

- enhancement: use `multi-stage` build strategy
- ci: separate `staging-dispatch-build` from `weekly-cron-build`
- chore: update `action/gh-release` version to `v0.1.15 (latest)`

## References

- https://github.com/techprober/v2dat
- https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts#passing-data-between-jobs-in-a-workflow