### PR TITLE
Docs: use jsonc for json syntax highlighting in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ steamstatic.com.8686c.com @cn
 - 最后，不命中任何路由规则的请求和流量，统统走代理
 - `outbounds` 里的第一个大括号内的配置，即为 V2Ray 代理服务的配置。请根据自身需求进行修改，并参照 V2Ray 官网配置文档中的 [配置 > Outbounds > OutboundObject](https://www.v2fly.org/config/outbounds.html#outboundobject) 部分进行补全
 
-```json
+```jsonc
 {
   "log": {
     "loglevel": "warning"


### PR DESCRIPTION
带有注释的 json 在 markdown 中需使用 `jsonc` 以显示正确的语法高亮

修改前：
<img width="714" alt="image" src="https://user-images.githubusercontent.com/1304342/216842289-0b42bb01-f740-4496-92a3-278988e68678.png">

修改后：
<img width="701" alt="image" src="https://user-images.githubusercontent.com/1304342/216842310-72fca2fe-e415-4eda-94ac-bf5c7bd0254d.png">
