### PR TITLE
Update reject-need-to-remove.txt

### DIFF
--- a/reject-need-to-remove.txt
+++ b/reject-need-to-remove.txt
@@ -32,3 +32,4 @@ tongji.baidu.com
 tv.sohu.com
 ue.yeyoucdn.com
 wl.spotify.com
+b-graph.facebook.com


### PR DESCRIPTION
Blocking b-graph.facebook.com will cause Facebook to be unable to log in.