### PR TITLE
Remove asmr.one and its related domain from direct-list

### DIFF
--- a/direct-need-to-remove.txt
+++ b/direct-need-to-remove.txt
@@ -2,6 +2,8 @@
 123cha.com
 95081.com
 airasia.com
+asmr-200.com
+asmr.one
 baid.us
 baidu.jp
 bussou.com
@@ -19,6 +21,7 @@ haitum.com
 hostloc.com
 jiaoyou8.com
 kh.google.com
+kiko-play-niptan.one
 laonanren.com
 mysinablog.com
 ntrqq.com


### PR DESCRIPTION
从直连列表中移除 asmr.one 及其相关域名

这些域名已经被 SNI 阻断 / DNS 污染

上游来自 felixonmars/dnsmasq-china-list ，这些域名被视为大陆可直连网站

但实际上这些域名只是用了 国内 NS，并没有国内服务器。


