### PR TITLE
Remove pikpak from direct-list

### DIFF
--- a/direct-need-to-remove.txt
+++ b/direct-need-to-remove.txt
@@ -20,6 +20,8 @@ hostloc.com
 jiaoyou8.com
 kh.google.com
 laonanren.com
+mypikpak.com
+mypikpak.net
 mysinablog.com
 ntrqq.com
 nytlog.com


### PR DESCRIPTION
pikpak域名同时存在直连和代理列表中，并且pikpak不再为中国提供服务，直连导致服务受限。[#420
](https://github.com/Loyalsoldier/v2ray-rules-dat/issues/420)