### PR TITLE
Add 'nikke-jp.com' to direct-need-to-remove

### DIFF
--- a/direct-need-to-remove.txt
+++ b/direct-need-to-remove.txt
@@ -27,6 +27,7 @@ mypikpak.com
 mypikpak.net
 mysinablog.com
 naixi.net
+nikke-jp.com
 ntrqq.com
 nytlog.com
 shuangtv.net


### PR DESCRIPTION
nikke-jp.com 目前存在于 direct 列中，由上游 [felixonmars/dnsmasq-china-list/accelerated-domains.china.conf](https://github.com/felixonmars/dnsmasq-china-list/blob/master/accelerated-domains.china.conf) 引入

该域名已被污染并指向 127.0.0.1，建议从 direct 中移除

<img width="1262" height="1212" alt="图片" src="https://github.com/user-attachments/assets/042c27dc-7934-49bf-8171-db7f45f72926" />
