### PR TITLE
Add domains to direct-need-to-remove.txt

### DIFF
--- a/direct-need-to-remove.txt
+++ b/direct-need-to-remove.txt
@@ -27,6 +27,13 @@ mypikpak.com
 mypikpak.net
 mysinablog.com
 naixi.net
+nikke-de.com
+nikke-en.com
+nikke-fr.com
+nikke-global.com
+nikke-jp.com
+nikke-kr.com
+nikke-sea.com
 ntrqq.com
 nytlog.com
 shuangtv.net


### PR DESCRIPTION
向 `direct-need-to-remove.txt` 增加以下域名：
```
nikke-de.com
nikke-en.com
nikke-fr.com
nikke-global.com
nikke-jp.com
nikke-kr.com
nikke-sea.com
```
以上域名，目前存在于 direct 列中，由上游 [felixonmars/dnsmasq-china-list/accelerated-domains.china.conf](https://github.com/felixonmars/dnsmasq-china-list/blob/master/accelerated-domains.china.conf) 引入。
上游仅依靠域名的 NS 服务器归属地来判断域名是否为中国 IP，以上域名虽使用了中国的 NS 服务器，但是均已被污染并指向 127.0.0.1

建议从 direct 中移除