### PR TITLE
Fix: Move perplexity to proxy.txt and direct-need-to-remove.txt

### DIFF
--- a/direct-need-to-remove.txt
+++ b/direct-need-to-remove.txt
@@ -41,3 +41,4 @@ ydy.com
 yslang.com
 perplexity.ai
 pplx.ai
+perplexity.com

--- a/direct-need-to-remove.txt
+++ b/direct-need-to-remove.txt
@@ -39,3 +39,5 @@ xjp.cc
 yanghengjun.com
 ydy.com
 yslang.com
+perplexity.ai
+pplx.ai

--- a/proxy.txt
+++ b/proxy.txt
@@ -1,2 +1,5 @@
 services.googleapis.cn
 supertop.co
+perplexity.ai
+pplx.ai
+perplexity.com


### PR DESCRIPTION
Perplexity 是美国 AI 服务，在中国大陆已被墙。
当前错误分类导致用户无法通过代理访问且geosite:cn包含其使得默认直连