### PR TITLE
intake-analytics.wikimedia.org被列入广告导致有时维基打不开

### DIFF
--- a/reject-need-to-remove.txt
+++ b/reject-need-to-remove.txt
@@ -15,6 +15,7 @@ d.ifengimg.com
 fabric.io
 icons.mydrivers.com
 img.alibaba.com
+intake-analytics.wikimedia.org
 jav321.com
 knet.cn
 mail.tsinghua.edu.cn


### PR DESCRIPTION
`Log(logLevel: LogLevel.info, payload: [TCP] [fdfe:dcba:9876::1]:62529(msedge.exe) --> intake-analytics.wikimedia.org:443 match RuleSet(AD) using AD[REJECT], dateTime: 2026-02-02 23:05:27)`