### PR TITLE
Update direct-need-to-remove.txt add lovart.ai

### DIFF
--- a/direct-need-to-remove.txt
+++ b/direct-need-to-remove.txt
@@ -22,6 +22,7 @@ jiaoyou8.com
 kh.google.com
 kox.moe
 laonanren.com
+lovart.ai
 mox.moe
 mypikpak.com
 mypikpak.net


### PR DESCRIPTION
lovart.ai 目前只能代理访问，无法直连。目前存在于 direct-list 和 china-list 和 gfw 中，需要从 direct-list 和 china-list 移除。 https://github.com/Loyalsoldier/v2ray-rules-dat/issues/493