### PR TITLE
DOH

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -28,6 +28,7 @@ jobs:
           echo "WIN_SPY=https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/spy.txt" >> $GITHUB_ENV
           echo "WIN_UPDATE=https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/update.txt" >> $GITHUB_ENV
           echo "WIN_EXTRA=https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/extra.txt" >> $GITHUB_ENV
+          echo "DOH_EXTRA=https://raw.githubusercontent.com/dibdot/DoH-IP-blocklists/master/doh-domains.txt" >> $GITHUB_ENV
         shell: bash
 
       - name: Checkout the "hidden" branch of this repo
@@ -163,6 +164,7 @@ jobs:
           curl -sSL $WIN_UPDATE | grep "0.0.0.0" | awk '{print $2}' > win-update.txt
           curl -sSL $WIN_EXTRA | grep "0.0.0.0" | awk '{print $2}' > ./community/data/win-extra
           curl -sSL $WIN_EXTRA | grep "0.0.0.0" | awk '{print $2}' > win-extra.txt
+          curl -sSL $DOH_EXTRA | awk 'NR == 1 { print "" } NF > 0 { print "full:"$0 }' >> ./community/data/category-doh
 
       - name: Build geosite.dat file
         run: |


### PR DESCRIPTION
Hi! The original category-doh doesn't include many necessary browser-specific domains, such as:

 - chrome.cloudflare-dns.com
 - chromium.dns.nextdns.io
 - firefox.dns.nextdns.io
 - mozilla.cloudflare-dns.com
 - opera.cloudflare-dns.com

I suggest expanding the category with an automatically updated list.
