### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -8,6 +8,8 @@ on:
       - master
     paths-ignore:
       - "**/README.md"
+permissions:
+  contents: write
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Loyalsoldier/v2ray-rules-dat/security/code-scanning/1](https://github.com/Loyalsoldier/v2ray-rules-dat/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/run.yml` (best at workflow root, just after `on:` block) so all jobs inherit it unless overridden.

For this workflow, the minimum practical permissions are:
- `contents: write` (needed for creating releases and pushing to `release` branch)

No other scopes are clearly required by the shown steps. This preserves existing behavior while documenting and constraining token access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
